### PR TITLE
Fix failure with changelog.txt

### DIFF
--- a/changelog_and_release.py
+++ b/changelog_and_release.py
@@ -292,7 +292,8 @@ def main():
 
     changelog = find_changelog()
     if changelog:
-        changelog_content = update_changelog(new_version, changelog_text, args.add_date)
+        changelog_content = update_changelog(changelog, new_version,
+                                             changelog_text, args.add_date)
         write_changelog(changelog, changelog_content)
 
     if args.update_news:


### PR DESCRIPTION
As per https://github.com/xbmc/inputstream.adaptive/runs/4988997617?check_suite_focus=true , the script currently fails updating changelog.txt

Although the update_changelog function currently accepts the parameters passed to it, the values are assigned to the wrong parameters. Tests don't fail as main() is not called under test - update_changelog() is called explicitly with correct parameters.

Tests still passing with this change.